### PR TITLE
fixed flaky test for toStringNoExplicitType method

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,9 +33,9 @@ jobs:
       run: mvn clean install -DskipTests -pl core -am
 
     - name: Run specific test case using maven
-      run: mvn -pl core test -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringNoExplicitType
+      run: mvn -pl core test -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringTest
 
     - name: Run the specific test case using the nondex tool
-      run: mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringNoExplicitType
+      run: mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringTest
     
     

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,9 +33,9 @@ jobs:
       run: mvn clean install -DskipTests -pl core -am
 
     - name: Run specific test case using maven
-      run: mvn -pl core test -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringTest
+      run: mvn -pl core test -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringNoExplicitType
 
     - name: Run the specific test case using the nondex tool
-      run: mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringTest
+      run: mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringNoExplicitType
     
     

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -399,14 +399,6 @@ public class ObjectSchemaTest {
         assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
     }
 
-    /*@Test
-    public void toStringNoExplicitType() {
-        JSONObject rawSchemaJson = loader.readObj("tostring/objectschema.json");
-        rawSchemaJson.remove("type");
-        String actual = SchemaLoader.load(rawSchemaJson).toString();
-        assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
-    }*/
-    
     @Test
     public void toStringNoExplicitType() {
         JSONObject rawSchemaJson = loader.readObj("tostring/objectschema.json");

--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -399,12 +399,42 @@ public class ObjectSchemaTest {
         assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
     }
 
-    @Test
+    /*@Test
     public void toStringNoExplicitType() {
         JSONObject rawSchemaJson = loader.readObj("tostring/objectschema.json");
         rawSchemaJson.remove("type");
         String actual = SchemaLoader.load(rawSchemaJson).toString();
         assertThat(new JSONObject(actual), sameJsonAs(rawSchemaJson));
+    }*/
+    
+    @Test
+    public void toStringNoExplicitType() {
+        JSONObject rawSchemaJson = loader.readObj("tostring/objectschema.json");
+        rawSchemaJson.remove("type");
+        String actual = SchemaLoader.load(rawSchemaJson).toString();
+        Map<String, Object> expectedMap = rawSchemaJson.toMap();        
+        Map<String, Object> actualMap = (new JSONObject(actual)).toMap();        
+        sortDependenciesValues(expectedMap);        
+        sortDependenciesValues(actualMap);        
+        assertThat(new JSONObject(actualMap), sameJsonAs(new JSONObject(expectedMap)));
+    }
+    
+    private void sortDependenciesValues(Map<String, Object> jsonObject) {
+        Object dependencies = jsonObject.get("dependencies");
+        if (dependencies instanceof Map) {
+             Map<String, List<String>> dependenciesMap = (Map<String, List<String>>) dependencies;
+             dependenciesMap.forEach((key, values) -> {
+             	for (int i = 1; i < values.size(); i++) {
+                	String keyToInsert = values.get(i);
+                	int j = i - 1;
+                	while (j >= 0 && values.get(j).compareTo(keyToInsert) > 0) {
+                    		values.set(j + 1, values.get(j));
+                    		j--;
+                	}
+                	values.set(j + 1, keyToInsert);
+            	}
+           });
+      }
     }
 
     @Test


### PR DESCRIPTION
## **What is the purpose of this PR**

- The ObjectSchemaTest class had flaky tests due to non-deterministic ordering of the expected map in the toStringNoExplicitType() method. 
- To resolve this problem, we needed to sort both the expected and actual JSON schemas. If the order of the expected schema changes, the test may become flaky again. 
- So, we have sorted both the actual and expected schemas to fix the issue and ensure consistent test results.

## **Why the tests fail**

- The unpredictable ordering of elements in the JSONArray of the expected and actual JSON objects in the toStringNoExplicitType test results in the failure of the test . 
-  Sorting both the expected and actual json schemas will solve this problem. Moreover the order of expected and actual json schemas does not matter which helps in maintaining the code.

## **Reproduce the test failure**

- It is expected to fail when the test is executed with nondex plugin using following command.

- `mvn -pl core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#toStringNoExplicitType`

 
## **Expected results**

- The test must pass when executed using the nondex

## **Actual Results**

T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.everit.json.schema.ObjectSchemaTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.148 s <<< FAILURE! - in org.everit.json.schema.ObjectSchemaTest
[ERROR] toStringNoExplicitType  Time elapsed: 0.103 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: 
`{
  "patternProperties": {"pattern_.*": {"type": "boolean"}},
  "required": ["numprop"],
  "minProperties": 3,
  "additionalProperties": {"type": "boolean"},
  "maxProperties": 4,
  "properties": {"numprop": {"type": "number"}},
  "dependencies": {"prop1": [
    "prop2",
    "prop3"
  ]}
}`


Actual:
`{
  "maxProperties": 4,
  "patternProperties": {"pattern_.*": {"type": "boolean"}},
  "properties": {"numprop": {"type": "number"}},
  "minProperties": 3,
  "dependencies": {"prop1": [
    "prop3",
    "prop2"
  ]},
  "required": ["numprop"],
  "additionalProperties": {"type": "boolean"}
}
at org.everit.json.schema.ObjectSchemaTest.toStringNoExplicitType(ObjectSchemaTest.java:403)`
 
	

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ObjectSchemaTest.toStringNoExplicitType:403 
Expected: 
`{
  "patternProperties": {"pattern_.*": {"type": "boolean"}},
  "required": ["numprop"],
  "minProperties": 3,
  "additionalProperties": {"type": "boolean"},
  "maxProperties": 4,
  "properties": {"numprop": {"type": "number"}},
  "dependencies": {"prop1": [
    "prop2",
    "prop3"
  ]}
}`


Actual:
` {
  "maxProperties": 4,
  "patternProperties": {"pattern_.*": {"type": "boolean"}},
  "properties": {"numprop": {"type": "number"}},
  "minProperties": 3,
  "dependencies": {"prop1": [
    "prop3",
    "prop2"
  ]},
  "required": ["numprop"],
  "additionalProperties": {"type": "boolean"}
}`

[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 

 
## **Fix**

- Sorted the JSONArray present in both the actual and expected JSON objects
- Sorted the expected json objects because even if the test requirements change in the future, the code remains consistent with the change.

